### PR TITLE
Fix example for `lab project browse` in docs

### DIFF
--- a/docs/lab_project_browse.md
+++ b/docs/lab_project_browse.md
@@ -9,7 +9,7 @@ lab project browse [remote] [flags]
 ### Examples
 
 ```
-lab mr browse origin
+lab project browse origin
 ```
 
 ### Options


### PR DESCRIPTION
Before this was 
`lab mr browse origin`
now it is
`lab project browse origin`